### PR TITLE
Small bugfix: deal with duplicate array items.

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -233,7 +233,7 @@ angular.module('JSONedit', ['ui.sortable'])
             + '<div class="jsonContents" ng-hide="collapsed">'
                 + '<ol class="arrayOl" ui-sortable="sortableOptions" ng-model="child">'
                     // repeat
-                    + '<li class="arrayItem" ng-repeat="val in child">'
+                    + '<li class="arrayItem" ng-repeat="val in child track by $index">'
                         // delete button
                         + '<i class="deleteKeyBtn glyphicon glyphicon-trash" ng-click="deleteKey(child, $index)"></i>'
                         + '<i class="moveArrayItemBtn glyphicon glyphicon-align-justify"></i>'


### PR DESCRIPTION
An error occurs when an array contains duplicates:
`Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: val in child, Duplicate key: number:0, Duplicate value: 0`
This can be reproduced in the demo page by duplicating the `"dreaming"` entry for example.
