### PR TITLE
fix array elements chevron bad positioning + fix bad sizing of array elements

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -134,7 +134,10 @@
     font-style: italic;
     font-family: Georgia, serif;
     list-style-type: decimal;
-    height: 30px;
+    min-height: 30px;
+}
+.jsonView ol.arrayOl li.arrayItem > span > span > .glyphicon-chevron-right, .jsonView ol.arrayOl li.arrayItem > span > span > .glyphicon-chevron-down {
+    right: 30px;
 }
 .jsonView ol.arrayOl li input, .jsonView li select, .jsonView li button {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Hi

In my previous pull request I've fixed height of array element to 30px
But after some testing, it's causing visual bug on array of array or array of object.

Height must not be fixed to 30px but minimum height of element is 30px.
With min-height 30px array of boolean is nice and array of array or array of object is correctly sized.

My bad, I'm sorry for that.

I've already fixed position of chevron (in collision with list style type)

see the difference between [your's](http://mb21.github.io/JSONedit/) and [mine](http://sparksx.github.io/JSONedit/)

![capture d ecran 2016-06-03 a 11 43 26](https://cloud.githubusercontent.com/assets/3260152/15775120/7c9f7b54-2980-11e6-9b56-41c2595fec60.png)
![capture d ecran 2016-06-03 a 11 43 36](https://cloud.githubusercontent.com/assets/3260152/15775119/7c9d5c7a-2980-11e6-9554-c351e52059ad.png)

tested with 
`{
  "test": [
    {
      "field": "value",
      "test": [
        {
          "boolean": [
            false,
            true
          ]
        }
      ]
    }
  ]
}` 

Sorry again
