### PR TITLE
(key,val) ng-repeat not updating

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -193,8 +193,8 @@ angular.module('JSONedit', ['ui.sortable'])
                 + '<span ng-switch-when="Number" type="number"><input type="text" ng-model="val" '
                     + 'placeholder="0" ng-model-onblur ng-change="child[key] = possibleNumber(val)"/>'
                 + '</span>'
-                + '<span ng-switch-default class="jsonLiteral"><input type="text" ng-model="val" '
-                    + 'placeholder="Empty" ng-model-onblur ng-change="child[key] = val"/>'
+                + '<span ng-switch-default class="jsonLiteral"><input type="text" ng-model="child[key]" '
+                    + 'placeholder="Empty" ng-model-onblur/>'
                 + '</span>'
             + '</span>';
         


### PR DESCRIPTION
"child" binding updates may not propagate to ng-repeat.
Using parent scope reference fixes this (simpler example here http://stackoverflow.com/questions/24774435/angularjs-ng-model-inside-ng-repeat-via-key-val-not-updating)

Bug steps are here http://stackoverflow.com/questions/41007472/a-bug-in-a-json-editor-by-angularjs
Note: updated only default switch, please fix other conditions.